### PR TITLE
fix: remove arg name for disabled entity constructor

### DIFF
--- a/pybind11_weaver/gen_code.py
+++ b/pybind11_weaver/gen_code.py
@@ -46,7 +46,7 @@ using {entity_struct_name} = {bind_struct_name}<>;
 #else
 
 struct {entity_struct_name} : public pybind11_weaver::DisabledEntity {{
-  explicit {entity_struct_name}(EntityScope parent_h){{}}
+  explicit {entity_struct_name}(EntityScope){{}}
   static const char * Key(){{ 
     return {unique_struct_key};
   }}


### PR DESCRIPTION
Hi!
I'm using strict compile rules in my project and I need to disable some entities at the same time.
Without this patch compiler will throw `unused parameter` warning (or error in my case).
Seems this argument name are not necessary.