### PR TITLE
Default shared_ptr holder

### DIFF
--- a/pybind11_weaver/entity/klass/klass.py
+++ b/pybind11_weaver/entity/klass/klass.py
@@ -116,6 +116,7 @@ virtual const char * AddCtor{id}(){{
                 and self.could_user_class_export(base_cursor.type)):
             t_param_list.append(common.safe_type_reference(base_cursor.type))
             self._dependency.add(common.safe_type_reference(base_cursor.type))
+        t_param_list.append(f"std::shared_ptr<{self.reference_name()}>")
         return f"pybind11::class_<{','.join(t_param_list)}>"
 
     def extra_code(self) -> str:


### PR DESCRIPTION
Hi!
pybind11_weaver is really nice tool, it does things well. But I faced next issue while using it.
I use dynamic polymorphism across the library for managing messages. Unfortunately pybind11 do not provide ability to conver from unique_ptr<Base> to shared_ptr<Derived>. So after pybind11-weaver generation I need to define shared_ptr<> holder for every type of message in result file.

What if pybind11-weaver will place this kind of holders automatically?